### PR TITLE
Fix CLI error around rollback with no label attribute (should default…

### DIFF
--- a/electrode-ota-server-routes-apps/src/index.js
+++ b/electrode-ota-server-routes-apps/src/index.js
@@ -337,9 +337,6 @@ export const register = diregister({
             method: 'POST',
             path: '/apps/{app}/deployments/{deployment}/rollback/{label?}',
             config: {
-                validate: {
-                    params: Object.assign({label: Joi.string()}, PARAMS.deployment)
-                },
                 payload: Object.assign({}, options.payload),
                 handler(request, reply)
                 {


### PR DESCRIPTION
… to prior release)

code-push rollback MyApp Staging
Are you sure? (y/N): y
[Error]  child "label" fails because ["label" is not allowed to be empty]