### PR TITLE
Fix code-push patch

### DIFF
--- a/electrode-ota-server-model-app/src/app.js
+++ b/electrode-ota-server-model-app/src/app.js
@@ -227,7 +227,7 @@ export default (options, dao, upload, download) => {
                     description
                 };
 
-                return dao.updatePackage(deployment.key, npkg);
+                return dao.updatePackage(deployment.key, npkg, params.label);
             })).then(toJSON);
         },
 


### PR DESCRIPTION
Previously a patch would always update the oldest version.  With this change a patch
updates the most recent version if no label is supplied (default behavior according to docs)
or it updates the specified label.